### PR TITLE
Remove leftover dependency placeholder

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-huggingface_hub==0.22.2
+# No external dependencies


### PR DESCRIPTION
## Summary
- drop unused `huggingface_hub` dependency, leaving requirements file as a placeholder

## Testing
- `python -m py_compile budget_app.py`


------
https://chatgpt.com/codex/tasks/task_e_68bb20bb74d88323a669c20334aa8b80