### PR TITLE
Add regex-based SMS and email transaction parsing

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-huggingface_hub==0.22.2
+# No external dependencies


### PR DESCRIPTION
## Summary
- extend `Transaction` with a currency field
- implement regex-based SMS and email parsers that support multiple date formats, international currencies, debit/credit keywords, and ignore failed or reversed messages

## Testing
- `python -m py_compile budget_app.py`


------
https://chatgpt.com/codex/tasks/task_e_68bb20bb74d88323a669c20334aa8b80